### PR TITLE
[#101894530] rename tmp old/new tables through raw SQL connection,

### DIFF
--- a/lib/mysql_big_table_migration.rb
+++ b/lib/mysql_big_table_migration.rb
@@ -115,8 +115,10 @@ module MySQLBigTableMigration
     end
 
     say "Replacing source table with temporary table..."
-    rename_table table_name, old_table_name
-    rename_table new_table_name, table_name
+    # TODO: revert back to the original way of using #rename_table
+    # Once we consolidate the migration and remove with_tmp_table from older migrations.
+    # see: https://github.com/analog-analytics/mysql_big_table_migration/blob/9780ca81ef34f0fc2defad2bb0769b0b1399b502/lib/mysql_big_table_migration.rb#L118-L119
+    connection.execute("RENAME TABLE #{table_name} TO #{old_table_name}, #{new_table_name} TO #{table_name}")
 
     say "Cleaning up, checking for rows created/updated during migration, dropping old table..."
     begin


### PR DESCRIPTION
instead of using #rename_table migration method.  Rails 4 changed
the #rename_table to also  rename table indexes, and it caused
several issues with our previous migrations with mysql big table
migrations.
